### PR TITLE
Pets

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,0 +1,6 @@
+class PetsController < ApplicationController
+
+  def index
+    @pets = Pet.all
+  end
+end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,0 +1,9 @@
+class Pet < ApplicationRecord
+  belongs_to :shelter
+  validates_presence_of :name
+  validates_presence_of :age
+  validates_presence_of :sex
+  validates_presence_of :description
+  validates_presence_of :status
+  enum status: [:adoptable, :pending, :adopted]
+end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,8 +1,8 @@
 class Shelter < ApplicationRecord
+  has_many :pets
   validates_presence_of :name,
                         :address,
                         :city,
                         :state,
                         :zip
-  
 end

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,0 +1,9 @@
+<h1>All Pets</h1>
+
+  <% @pets.each do |pet| %>
+    <%= pet.image %>
+    <p>Name: <%= pet.name %>
+    <p>Age: <%= pet.age %>
+    <p>Sex: <%= pet.sex %>
+    <p>Belongs To: <%= pet.shelter.name %></p>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # SHELTERS ROUTES
   get '/shelters', to: 'shelters#index'
   get 'shelters/new', to: 'shelters#new'
   get '/shelters/:id', to: 'shelters#show'
@@ -7,4 +8,7 @@ Rails.application.routes.draw do
   get '/shelters/:id/edit', to: 'shelters#edit'
   patch '/shelters/:id', to: 'shelters#update'
   delete '/shelters/:id', to: 'shelters#destroy'
+
+  # PETS ROUTES
+  get '/pets', to: 'pets#index'
 end

--- a/db/migrate/20201008223224_create_pets.rb
+++ b/db/migrate/20201008223224_create_pets.rb
@@ -1,0 +1,11 @@
+class CreatePets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pets do |t|
+      t.string :name
+      t.string :image
+      t.string :age
+      t.string :sex
+      t.string :description
+    end
+  end
+end

--- a/db/migrate/20201008230630_add_status_to_pets.rb
+++ b/db/migrate/20201008230630_add_status_to_pets.rb
@@ -1,0 +1,5 @@
+class AddStatusToPets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pets, :status, :integer
+  end
+end

--- a/db/migrate/20201008233111_add_sheltersto_pets.rb
+++ b/db/migrate/20201008233111_add_sheltersto_pets.rb
@@ -1,0 +1,5 @@
+class AddShelterstoPets < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :pets, :shelter, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_220053) do
+ActiveRecord::Schema.define(version: 2020_10_08_233111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "pets", force: :cascade do |t|
+    t.string "name"
+    t.string "image"
+    t.string "age"
+    t.string "sex"
+    t.string "description"
+    t.integer "status"
+    t.bigint "shelter_id"
+    t.index ["shelter_id"], name: "index_pets_on_shelter_id"
+  end
 
   create_table "shelters", force: :cascade do |t|
     t.string "name"
@@ -25,4 +36,5 @@ ActiveRecord::Schema.define(version: 2020_10_07_220053) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "pets", "shelters"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,16 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-4.times do
-  FactoryBot.create(:shelter)
-end
+# 4.times do
+#   FactoryBot.create(:shelter)
+# end
+
+shelter1 = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+shelter2 = Shelter.create(name: "Bovice's pet shop", address: "1060 W Addison", city: "Chicago", state: "Illinois", zip: "61109")
+shelter3 = Shelter.create(name: "Jared's pet shop", address: "343 Bungie Dr", city: "Littleton", state: "Colorado", zip: "80128")
+shelter4 = Shelter.create(name: "Old Greg's pet shop", address: "115 rona st", city: "Denver", state: "Colorado", zip: "80200")
+
+shelter1.pets.create(image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", name: "Bella", age: "5", sex: "female", description: "Fun Loving Dog", status: 0)
+shelter2.pets.create(image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", name: "Maisy", age: "6", sex: "female", description: "Stomache on legs", status: 0)
+shelter3.pets.create(image: "https://media.wired.com/photos/5cdefb92b86e041493d389df/master/pass/Culture-Grumpy-Cat-487386121.jpg", name: "Mr. Cat", age: "9", sex: "male", description: "Has Russian accent", status: 0)
+shelter4.pets.create(image: "https://i.dailymail.co.uk/1s/2020/03/20/13/26207684-0-image-a-4_1584711978894.jpg", name: "Frank", age: "3", sex: "male", description: "He's a snake. does snake things", status: 0)

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe "As a visitor" do
+  describe "when i visit the pets index page" do
+    it "I see each pet in the system" do
+      shelter_1 = create(:shelter)
+      shelter_2 = create(:shelter)
+      shelter_3 = create(:shelter)
+      shelter_4 = create(:shelter)
+
+      pet1 = shelter_1.pets.create!(name: "Bella", image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", age: "5", sex: "Female", description: "Bork", status: 0)
+      pet2 = shelter_2.pets.create!(name: "Mr.Cat", image: "https://media.wired.com/photos/5cdefb92b86e041493d389df/master/pass/Culture-Grumpy-Cat-487386121.jpg", age: "8", sex: "Male", description: "Has Russian Accent", status: 0)
+      pet3 = shelter_3.pets.create!(name: "maisy", image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", age: "4", sex: "Female", description: "Stomach on legs", status: 0)
+      pet4 = shelter_4.pets.create!(name: "Frank", image: "https://i.dailymail.co.uk/1s/2020/03/20/13/26207684-0-image-a-4_1584711978894.jpg", age: "unkown", sex: "Male", description: "Danger Noodle", status: 0)
+
+      visit "/pets"
+
+      expect(page).to have_content(pet1.name)
+      expect(page).to have_content(pet1.image)
+      expect(page).to have_content(pet1.age)
+      expect(page).to have_content(pet1.sex)
+      expect(page).to have_content(shelter_1.name)
+      expect(page).to have_content(pet2.name)
+      expect(page).to have_content(pet2.image)
+      expect(page).to have_content(pet2.age)
+      expect(page).to have_content(pet2.sex)
+      expect(page).to have_content(shelter_2.name)
+      expect(page).to have_content(pet3.name)
+      expect(page).to have_content(pet3.image)
+      expect(page).to have_content(pet3.age)
+      expect(page).to have_content(pet3.sex)
+      expect(page).to have_content(shelter_3.name)
+      expect(page).to have_content(pet4.name)
+      expect(page).to have_content(pet4.image)
+      expect(page).to have_content(pet4.age)
+      expect(page).to have_content(pet4.sex)
+      expect(page).to have_content(shelter_4.name)
+    end
+  end
+end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Pet, type: :model do
+  describe "validations" do
+    it {should validate_presence_of :name}
+    it {should validate_presence_of :age}
+    it {should validate_presence_of :sex}
+    it {should validate_presence_of :description}
+  end
+
+  describe "relationships" do
+    it { should belong_to :shelter }
+  end
+end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -8,4 +8,8 @@ describe Shelter, type: :model do
     it {should validate_presence_of :state}
     it {should validate_presence_of :zip}
   end
+
+  describe "relationships" do
+    it { should have_many :pets }
+  end
 end


### PR DESCRIPTION
Add Feature that allows a visitor to see all pets on the pets index page. /pets

- Add all migrations for pets
- Add relationship test for shelters having many pets
- Add model tests for pet
- Add Pet model with validations and association
- Add has many pets association
- Add shelters and pets to Seed to database
- Add test that a visitor can see all pets on the pet index page
- Create pets controller and index action
- Add pets index page
- Add route for a pets index page