### PR TITLE
Usability

### DIFF
--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -6,7 +6,7 @@
       <p>Name: <%= pet.name %></p>
       <p>Age: <%= pet.age %></p>
       <p>Sex: <%= pet.sex %></p>
-      <p>Belongs To: <%= pet.shelter.name %></p>
+      <p>Belongs To: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %></p>
       <%= link_to "Update Pet", "/pets/#{pet.id}/edit" %><br>
       <%= link_to "Delete Pet", "/pets/#{pet.id}/delete", method: :delete %><br><br>
     </section>

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @shelters.each do |shelter| %>
 <section class="shelter-<%= shelter.id %>">
-  <%= shelter.name %><br>
+  <%= link_to "#{shelter.name}", "/shelters/#{shelter.id}" %><br>
   <%= link_to "Update Shelter", "/shelters/#{shelter.id}/edit" %>
   <%= link_to "Delete Shelter", "/shelters/#{shelter.id}", method: :delete %><br><br>
 </section>

--- a/app/views/shelters/pets.html.erb
+++ b/app/views/shelters/pets.html.erb
@@ -1,4 +1,4 @@
-<h1>Welcome to <%= @shelter.name %> Pets Page</h1>
+<h1>Welcome to <%= link_to "#{@shelter.name}", "/shelters/#{@shelter.id}"  %> Pets Page</h1>
 
 <% @shelter.pets.each do |pet| %>
   <section class="pets-<%= pet.id %>">

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -72,5 +72,19 @@ describe "As a visitor" do
 
       expect(page).to_not have_content(pet1.name)
     end
+    it "I can click on shelters name and got to that shelters show page" do
+      shelter_1 = create(:shelter)
+      shelter_2 = create(:shelter)
+
+      pet1 = shelter_1.pets.create!(name: "Bella", image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", age: "5", sex: "Female", description: "Bork", status: 0)
+      pet2 = shelter_2.pets.create!(name: "Mr.Cat", image: "https://media.wired.com/photos/5cdefb92b86e041493d389df/master/pass/Culture-Grumpy-Cat-487386121.jpg", age: "8", sex: "Male", description: "Has Russian Accent", status: 0)
+
+      visit "/pets"
+
+      within ".pets-#{pet1.id}" do
+        click_link "#{shelter_1.name}"
+      end
+      expect(current_path).to eq("/shelters/#{shelter_1.id}")
+    end
   end
 end

--- a/spec/features/shelters/index_spec.rb
+++ b/spec/features/shelters/index_spec.rb
@@ -46,5 +46,23 @@ describe "As a visitor" do
       expect(current_path).to eq("/shelters/#{shelter_2.id}")
       expect(page).to have_content("Van's catto Shelter")
     end
+    it "I can click on the shelters name and take me to its show page" do
+      shelter_1 = create(:shelter)
+      shelter_2 = create(:shelter)
+
+      visit "/shelters"
+
+      within ".shelter-#{shelter_2.id}" do
+        click_link "#{shelter_2.name}"
+      end
+      expect(current_path).to eq("/shelters/#{shelter_2.id}")
+
+      visit "/shelters"
+
+      within ".shelter-#{shelter_1.id}" do
+        click_link "#{shelter_1.name}"
+      end
+      expect(current_path).to eq("/shelters/#{shelter_1.id}")
+    end
   end
 end

--- a/spec/features/shelters/shelter_pets_index_spec.rb
+++ b/spec/features/shelters/shelter_pets_index_spec.rb
@@ -61,4 +61,17 @@ RSpec.describe "Shelter specific index page" do
     end
     expect(page).to_not have_content(pet1.name)
   end
+  it "I can click on the shelters name and go to it's show page" do
+    shelter_1 = create(:shelter)
+
+
+    pet1 = shelter_1.pets.create!(name: "Bella", image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", age: "5", sex: "Female", description: "Bork", status: 0)
+    pet2 = shelter_1.pets.create!(name: "Mr.Cat", image: "https://media.wired.com/photos/5cdefb92b86e041493d389df/master/pass/Culture-Grumpy-Cat-487386121.jpg", age: "8", sex: "Male", description: "Has Russian Accent", status: 0)
+
+    visit "/shelters/#{shelter_1.id}/pets"
+
+    click_link "#{shelter_1.name}"
+
+    expect(current_path).to eq("/shelters/#{shelter_1.id}")
+  end
 end


### PR DESCRIPTION
Add feature that anywhere a shelters name is displayed that it is a link to its show page.

- Add tests for everywhere on the site that a shelters name is a link to its show page, except on the show page
- Add shelter name links to that shelters show page where a shelters name is displayed